### PR TITLE
pc - add project to nav

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -77,6 +77,8 @@ aux_links: # TODO - update to yours
     - 'https://www.gradescope.com/courses/484136/'
   "Main CS8 W Site":
     - 'https://ucsb-csw8.github.io'
+  "w23-project (both sections)":
+    - "//ucsb-csw8.github.io/w23-project/"
 aux_links_new_tab: true
 
 # TODO - change to your name


### PR DESCRIPTION
In this PR, we add a link to the project description to the top navigation (at upper right.)


Before:

<img width="1132" alt="image" src="https://user-images.githubusercontent.com/1119017/223509821-4156aa25-f0aa-411b-b73e-a7053d02817d.png">


After:

<img width="1039" alt="image" src="https://user-images.githubusercontent.com/1119017/223509762-61718c71-f087-4bbe-a234-2264da6300d2.png">
